### PR TITLE
Alt combo support

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -4,13 +4,14 @@ package keyboard
 
 import (
 	"errors"
-	"golang.org/x/sys/unix"
 	"os"
 	"os/signal"
 	"runtime"
 	"strings"
 	"syscall"
 	"unicode/utf8"
+
+	"golang.org/x/sys/unix"
 )
 
 type (
@@ -46,6 +47,14 @@ func parse_escape_sequence(buf []byte) (size int, event KeyEvent) {
 			size = len(key)
 			return
 		}
+	}
+
+	// Might be an Alt combo in format of ESC+letter
+	if buf[0] == '\033' {
+		event.Key = KeyEsc
+		event.Rune, size = utf8.DecodeRune(buf[1:])
+		size = len(buf)
+		return
 	}
 	return 0, event
 }


### PR DESCRIPTION
This diff adds support for ALT+letter combinations. If an escape sequence is detected, but not found in `terminfo` we try to pass it along as a Key + Rune.

I suspect this will cause issues for existing programs. They might have logic that assumes the presence of `KeyEvent.Key` means there's no Rune. I'm new to this project so welcome alternatives. :) (cc @eiannone)

In the meantime I'll need one of my projects to depend on my fork -- which I hate doing.