### PR TITLE
Allow `{` & `[` for german keyboards on windows

### DIFF
--- a/keyboard_windows.go
+++ b/keyboard_windows.go
@@ -180,9 +180,9 @@ func getKeyEvent(r *k32_event) (KeyEvent, bool) {
 			e.Key = KeyCtrl5
 		case 54:
 			e.Key = KeyCtrl6
-		case 189, 191: //, 55:
+		case 189, 191:
 			e.Key = KeyCtrl7
-		case 8: //, 56:
+		case 8:
 			e.Key = KeyCtrl8
 		}
 

--- a/keyboard_windows.go
+++ b/keyboard_windows.go
@@ -180,9 +180,9 @@ func getKeyEvent(r *k32_event) (KeyEvent, bool) {
 			e.Key = KeyCtrl5
 		case 54:
 			e.Key = KeyCtrl6
-		case 189, 191, 55:
+		case 189, 191: //, 55:
 			e.Key = KeyCtrl7
-		case 8, 56:
+		case 8: //, 56:
 			e.Key = KeyCtrl8
 		}
 


### PR DESCRIPTION
Allow keys:

- `{` (`Alt Gr`+  `7`)
- `[` (`Alt Gr`+  `8`)

for German keyboards on Windows...

maybe this has some side effects... but it works for me.

Fix #27