### PR TITLE
Add compatibility for tmux

### DIFF
--- a/terminfo.go
+++ b/terminfo.go
@@ -53,6 +53,7 @@ var (
 		{"screen", screen_keys},
 		{"xterm", xterm_keys},
 		{"xterm-256color", xterm_keys},
+		{"tmux-256color", xterm_keys},
 		{"rxvt-unicode", rxvt_keys},
 		{"rxvt-256color", rxvt_keys},
 		{"linux", linux_keys},


### PR DESCRIPTION
`keyboard` doesn't work for tmux. Particularly, keys like the arrow keys just show up as a rune: `[`.

This PR adds support for `tmux-256color` by simply mapping it to `xterm`. I'm not totally confident that this is 100% correct, but it does get arrow keys working again.